### PR TITLE
Allow hasql-pool 0.7

### DIFF
--- a/hasql-notifications.cabal
+++ b/hasql-notifications.cabal
@@ -1,5 +1,5 @@
 name:                hasql-notifications
-version:             0.2.0.0
+version:             0.2.0.1
 synopsis:            LISTEN/NOTIFY support for Hasql
 description:         Use PostgreSQL Asynchronous notification support with your Hasql Types.
 homepage:            https://github.com/diogob/hasql-notifications
@@ -19,7 +19,7 @@ library
   build-depends:       base >= 4.7 && < 5
                      , bytestring >= 0.10.8.2
                      , text >= 1.2.3.1 && < 1.3
-                     , hasql-pool >= 0.4 && < 0.6
+                     , hasql-pool >= 0.4 && < 0.8
                      , bytestring >= 0.10
                      , postgresql-libpq >= 0.9 && < 1.0
                      , hasql >= 0.19


### PR DESCRIPTION
The CI will test against the version in stackage LTS 19.9 but I have compiled and tested against 0.7 and it seems to work fine.

This should address https://github.com/commercialhaskell/stackage/issues/6601