### PR TITLE
Relax constraint to allow hasql-0.9

### DIFF
--- a/hasql-notifications.cabal
+++ b/hasql-notifications.cabal
@@ -19,7 +19,7 @@ library
   build-depends:       base >= 4.7 && < 5
                      , bytestring >= 0.10.8.2
                      , text >= 1.2.3.1 && < 2.2
-                     , hasql-pool >= 0.4 && < 0.9
+                     , hasql-pool >= 0.4 && < 0.10
                      , bytestring >= 0.10
                      , postgresql-libpq >= 0.9 && < 1.0
                      , hasql >= 0.19


### PR DESCRIPTION
This should address https://github.com/commercialhaskell/stackage/issues/6933

