### PR TITLE
Add support for hasql 1.9

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -4,6 +4,8 @@ import System.IO
 import System.Exit (die)
 
 import Hasql.Connection
+import Hasql.Connection.Setting
+import Hasql.Connection.Setting.Connection
 import Hasql.Notifications
 
 main :: IO ()
@@ -11,11 +13,10 @@ main = do
     hSetBuffering stdout NoBuffering
     hSetBuffering stderr NoBuffering
 
-    dbOrError <- acquire "postgres://localhost/db_name"
+    dbOrError <- acquire [ connection $ string "postgres://localhost/db_name" ]
     case dbOrError of
         Right db -> do
             let channelToListen = toPgIdentifier "sample-channel"
             listen db channelToListen
             waitForNotifications (\channel _ -> print $ "Just got notification on channel " <> channel) db
         _ -> die "Could not open database connection"
-

--- a/hasql-notifications.cabal
+++ b/hasql-notifications.cabal
@@ -19,9 +19,9 @@ library
   build-depends:       base >= 4.7 && < 5
                      , bytestring >= 0.10.8.2 && < 0.13
                      , text >= 2 && < 2.2
-                     , hasql-pool >= 1.2 && < 1.3
+                     , hasql-pool >= 1.3 && < 1.4
                      , postgresql-libpq >= 0.9 && < 1.0
-                     , hasql >= 0.19 && < 1.9
+                     , hasql >= 1.9 && < 1.10
 
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/src/Hasql/Notifications.hs
+++ b/src/Hasql/Notifications.hs
@@ -99,11 +99,13 @@ notify con channel mesg =
 --  import System.Exit (die)
 --
 --  import Hasql.Connection
+--  import Hasql.Connection.Setting
+--  import Hasql.Connection.Setting.Connection
 --  import Hasql.Notifications
 --
 --  main :: IO ()
 --  main = do
---    dbOrError <- acquire "postgres://localhost/db_name"
+--    dbOrError <- acquire [ connection $ string "postgres://localhost/db_name" ]
 --    case dbOrError of
 --        Right db -> do
 --            let channelToListen = toPgIdentifier "sample-channel"
@@ -160,6 +162,8 @@ executeOrPanic cmd pqCon = do
 --  import System.Exit (die)
 --
 --  import Hasql.Connection
+--  import Hasql.Connection.Setting
+--  import Hasql.Connection.Setting.Connection
 --  import Hasql.Notifications
 --
 --  notificationHandler :: ByteString -> ByteString -> IO()
@@ -169,7 +173,7 @@ executeOrPanic cmd pqCon = do
 --
 --  main :: IO ()
 --  main = do
---    dbOrError <- acquire "postgres://localhost/db_name"
+--    dbOrError <- acquire [ connection $ string "postgres://localhost/db_name" ]
 --    case dbOrError of
 --        Right db -> do
 --            let channelToListen = toPgIdentifier "sample-channel"

--- a/test/Hasql/NotificationsSpec.hs
+++ b/test/Hasql/NotificationsSpec.hs
@@ -5,6 +5,8 @@ import Control.Concurrent.MVar
 import Control.Monad (void)
 import Data.ByteString
 import Hasql.Connection
+import Hasql.Connection.Setting
+import Hasql.Connection.Setting.Connection
 import Hasql.Notifications
 import System.Exit (die)
 import Test.Hspec
@@ -20,7 +22,7 @@ spec = do
   describe "send and receive notification" $
     describe "when I send a notification to channel my handler is listening to" $
       it "should call our notification handler" $ do
-        dbOrError <- acquire "postgres://postgres:roottoor@localhost/hasql_notifications_test"
+        dbOrError <- acquire [ connection $ string "postgres://postgres:roottoor@localhost/hasql_notifications_test"]
         case dbOrError of
           Right db -> do
             let channelToListen = toPgIdentifier "test-channel"


### PR DESCRIPTION
There's no `hasql-notifications` version that supports `hasql` 1.9 yet. [Adapting to the new way the connection is done](https://github.com/nikita-volkov/hasql/blob/e367684082834a16beb24e71db514ff998ab7310/CHANGELOG.md#instructions-on-upgrading-the-18-code) seems to be the only change needed.